### PR TITLE
Add ansible_ssh_user to generated inventory file

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Heat stack.
     * `name`: A name to refer to this group
     * `flavor`: The name or UUID of an instance flavor to use for deploying this group.
     * `image`: The name or UUID of an image to use for deploying this group.
+    * `user`: The name of a cloud user for which SSH keys have been provisioned and
+      passwordless sudo has been configured.  Could be (for example), `centos`, `debian`
+      or `ubuntu`.
     * `num_nodes`: The number of nodes to create within this group.
     * `volume_size`: Optional size in GB of volumes used to boot instances in
       this group when the `instance-w-volume.yaml` environment is used.

--- a/templates/cluster_inventory.j2
+++ b/templates/cluster_inventory.j2
@@ -12,7 +12,7 @@ localhost ansible_connection=local ansible_python_interpreter=python
 {% for group_data in output.output_value %}
 [{{ cluster_stack.stack.stack_name}}_{{ group_data.group }}]
 {% for node_data in group_data.nodes %}
-{{node_data.name}} ansible_host={{ node_data.ip }}
+{{node_data.name}} ansible_host={{ node_data.ip }} ansible_ssh_user={{ cluster_groups | selectattr("name", "equalto", group_data.group) | map(attribute='user') | join }}
 {% endfor %}
 
 {% endfor %}


### PR DESCRIPTION
Here's what we talked about the other day.  Is there a sensible way to incorporate a default?