### PR TITLE
cluster_groups is passed in the cluster_params dict

### DIFF
--- a/templates/cluster_inventory.j2
+++ b/templates/cluster_inventory.j2
@@ -12,7 +12,7 @@ localhost ansible_connection=local ansible_python_interpreter=python
 {% for group_data in output.output_value %}
 [{{ cluster_stack.stack.stack_name}}_{{ group_data.group }}]
 {% for node_data in group_data.nodes %}
-{{node_data.name}} ansible_host={{ node_data.ip }} ansible_user={{ cluster_groups | selectattr("name", "equalto", group_data.group) | map(attribute='user') | join }}
+{{node_data.name}} ansible_host={{ node_data.ip }} ansible_user={{ cluster_params.cluster_groups | selectattr("name", "equalto", group_data.group) | map(attribute='user') | join }}
 {% endfor %}
 
 {% endfor %}


### PR DESCRIPTION
this only worked because in p3 appliances because we build up the cluster_params dict using "top-level" variables https://github.com/stackhpc/p3-appliances/blob/master/ansible/cluster-infra.yml#L10, i.e the variable cluster_groups is defined: https://github.com/stackhpc/p3-appliances/blob/master/config/maintenance.yml#L17