### PR TITLE
Add support for querying an existing cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ use.
 
 `cluster_cloud`: Optional name of the OpenStack client config cloud name to use.
 
-`cluster_state`: Desired state of the cluster, either `present` or `absent`.
-The default value is `present`.
+`cluster_state`: Desired state of the cluster, one of `present`, `absent`, or
+`query`.  The default value is `present`. If the value is `query`, the cluster
+will not be updated, but its configuration will be queried and an Ansible
+inventory generated.
 
 `cluster_name`: Name to give the Heat stack
 It defaults to `cluster`

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,17 +9,36 @@
     ansible_python_interpreter: "{{ cluster_venv }}/bin/python"
   when: cluster_venv != None
 
-- name: Orchestrate OpenStack infrastructure
-  register: cluster_stack
-  os_stack:
-    auth_type: "{{ cluster_auth_type or omit }}"
-    auth: "{{ cluster_auth or omit }}"
-    cloud: "{{ cluster_cloud or omit }}"
-    name: "{{ cluster_name }}"
-    state: "{{ cluster_state }}"
-    environment: "{{ cluster_environment }}"
-    template: "{{ cluster_template }}"
-    parameters: "{{ cluster_params }}"
+# Case 1: we are modifying the cluster.
+- block:
+    - name: Orchestrate OpenStack infrastructure
+      register: cluster_stack
+      os_stack:
+        auth_type: "{{ cluster_auth_type or omit }}"
+        auth: "{{ cluster_auth or omit }}"
+        cloud: "{{ cluster_cloud or omit }}"
+        name: "{{ cluster_name }}"
+        state: "{{ cluster_state }}"
+        environment: "{{ cluster_environment }}"
+        template: "{{ cluster_template }}"
+        parameters: "{{ cluster_params }}"
+
+    - name: Extract node groups
+      set_fact:
+        cluster_group: "{{ cluster_stack.stack.outputs | selectattr('output_key', 'equalto', 'cluster_group') | first }}"
+  when: cluster_state != 'query'
+
+# Case 2: we are performing a read-only query of the cluster configuration.
+# Read the stack's outputs via the API.
+- block:
+    - name: Gather OpenStack infrastructure information
+      command: openstack stack output show {{ cluster_name }} cluster_group -f json
+      register: stack_output
+
+    - name: Extract node groups
+      set_fact:
+        cluster_group: "{{ stack_output.stdout | from_json }}"
+  when: cluster_state == 'query'
 
 - name: Reset the python interpreter
   set_fact:
@@ -37,10 +56,6 @@
         src: cluster_inventory.j2
         dest: "{{ cluster_inventory }}"
 
-    - name: Extract node groups
-      set_fact:
-        cluster_group: "{{ cluster_stack.stack.outputs | selectattr('output_key', 'equalto', 'cluster_group') | first }}"
-
     - name: Extract node objects
       set_fact:
         cluster_nodes: "{{ cluster_group.output_value | map(attribute='nodes') | list }}" 
@@ -54,4 +69,4 @@
         timeout: "{{ cluster_ssh_timeout }}"
       with_flattened:
         - "{{ cluster_nodes }}"
-  when: cluster_state == 'present'
+  when: cluster_state != 'absent'

--- a/templates/cluster_inventory.j2
+++ b/templates/cluster_inventory.j2
@@ -2,27 +2,23 @@
 [openstack]
 localhost ansible_connection=local ansible_python_interpreter=python
 
-{% for output in cluster_stack.stack.outputs %}
-{% if output.output_key == "cluster_group" %}
 [cluster:children]
-{% for group_data in output.output_value %}
-{{ cluster_stack.stack.stack_name}}_{{ group_data.group }}
+{% for group_data in cluster_group.output_value %}
+{{ cluster_name }}_{{ group_data.group }}
 {% endfor %}
 
-{% for group_data in output.output_value %}
-[{{ cluster_stack.stack.stack_name}}_{{ group_data.group }}]
+{% for group_data in cluster_group.output_value %}
+[{{ cluster_name}}_{{ group_data.group }}]
 {% for node_data in group_data.nodes %}
 {{node_data.name}} ansible_host={{ node_data.ip }} ansible_user={{ cluster_params.cluster_groups | selectattr("name", "equalto", group_data.group) | map(attribute='user') | join }}
 {% endfor %}
 
 {% endfor %}
-{% endif %}
-{% endfor %}
 # Specific roles for cluster deployment assignments
 {% for role in cluster_roles %}
 [cluster_{{ role.name }}:children]
 {% for group in role.groups %}
-{{ cluster_stack.stack.stack_name}}_{{ group.name }}
+{{ cluster_name}}_{{ group.name }}
 {% endfor %}
 
 {% endfor %}

--- a/templates/cluster_inventory.j2
+++ b/templates/cluster_inventory.j2
@@ -16,9 +16,9 @@ cluster
 {% endfor %}
 
 {% for group_data in cluster_group.output_value %}
-[{{ cluster_name}}_{{ group_data.group }}]
+[{{ cluster_name }}_{{ group_data.group }}]
 {% for node_data in group_data.nodes %}
-{{node_data.name}} ansible_host={{ node_data.ip }} ansible_user={{ cluster_params.cluster_groups | selectattr("name", "equalto", group_data.group) | map(attribute='user') | join }}
+{{ node_data.name }} ansible_host={{ node_data.ip }} ansible_user={{ cluster_params.cluster_groups | selectattr("name", "equalto", group_data.group) | map(attribute='user') | join }}
 {% endfor %}
 
 {% endfor %}
@@ -26,7 +26,7 @@ cluster
 {% for role in cluster_roles %}
 [cluster_{{ role.name }}:children]
 {% for group in role.groups %}
-{{ cluster_name}}_{{ group.name }}
+{{ cluster_name }}_{{ group.name }}
 {% endfor %}
 
 {% endfor %}


### PR DESCRIPTION
The cluster_state variable can now take a third value - 'query'.

I added this during the EoD slurm deployment. It's on the group-resources-wip branch, but thought it could be merged separately.