### PR TITLE
Support adding all hosts to a single group

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ that is generated.  This parameter is a list of dicts of the form:
 to be defined for that group. The group variables for each group are defined as
 a dictionary mapping variable names to their values.
 
+`cluster_environment_group`: An optional Ansible group name to which all
+cluster hosts and localhost will be added. This can be useful if there is a
+single group that represents an environment such as
+development/staging/production.
+
 Dependencies
 ------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,3 +16,4 @@ cluster_roles: []
 cluster_group_vars: {}
 cluster_inventory: "{{ playbook_dir }}/inventory-{{ cluster_name }}"
 cluster_ssh_timeout: 600
+cluster_environment_group:

--- a/templates/cluster_inventory.j2
+++ b/templates/cluster_inventory.j2
@@ -2,6 +2,12 @@
 [openstack]
 localhost ansible_connection=local ansible_python_interpreter=python
 
+{% if cluster_environment_group is not none %}
+[{{ cluster_environment_group }}:children]
+openstack
+cluster
+{% endif %}
+
 {% for output in cluster_stack.stack.outputs %}
 {% if output.output_key == "cluster_group" %}
 [cluster:children]


### PR DESCRIPTION
Adds a new variable, cluster_environment_group, that can be used to set the
name of an Ansible group to which all cluster hosts and localhost will be
added.

This can be useful if there is a single group that represents an environment
such as development/staging/production.