### PR TITLE
Add support for ports configured for hosts acting as routers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,12 @@ Heat stack.
     permitted networks.  This is needed if a port is associated with a gateway node that
     is performing IP routing between subnets.  These should match the format of `allowed_address_pairs`
     [https://docs.openstack.org/heat/rocky/template_guide/openstack.html#OS::Neutron::Port-prop-allowed_address_pairs here].
-    A simple, permissive configuration for `router_networks` would be: `[ ip_address: "0.0.0.0/0" ]`
+    A simple, permissive configuration for `router_networks` would be: 
+    
+```
+    router_networks:
+      - ip_address: "0.0.0.0/0"
+```
 
 `cluster_inventory`: After deployment, an inventory file is generated,
 which can be used in subsequent Ansible-driven configuration.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ The OpenStack APIs should be accessible from the target host.  OpenStack
 Newton or later is required.  Client credentials should have been set
 in the environment, or using the `clouds.yaml` format.
 
-Module Parameters
------------------
+Role Variables
+--------------
 
 `cluster_venv`: Optional path to a python virtualenv in which the python
 `shade` package is installed.
@@ -118,8 +118,8 @@ Heat stack.
     A simple, permissive configuration for `router_networks` would be: 
     
 ```
-    router_networks:
-      - ip_address: "0.0.0.0/0"
+router_networks:
+  - ip_address: "0.0.0.0/0"
 ```
 
 `cluster_inventory`: After deployment, an inventory file is generated,

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ The OpenStack APIs should be accessible from the target host.  OpenStack
 Newton or later is required.  Client credentials should have been set
 in the environment, or using the `clouds.yaml` format.
 
-Role Variables
---------------
+Module Parameters
+-----------------
 
 `cluster_venv`: Optional path to a python virtualenv in which the python
 `shade` package is installed.
@@ -104,10 +104,18 @@ Heat stack.
       This is the default.
     * `Cluster::NodeNet1WithFIP`: A single network with floating IP allocated
       and associated with the port.
+    * `Cluster::NodeNet1WithPreallocatedFIP`: A single network with floating IP
+      (taken from a pre-allocated and supplied list) and associated with the port.
     * `Cluster::NodeNet2`: Two network interfaces.  The first two networks listed
       in `cluster_net` are used.
     * `Cluster::NodeNet3`: Three network interfaces.  The first three networks listed
       in `cluster_net` are used.
+
+  * `router_networks`: An optional list of IP subnet CIDRs that should be added as
+    permitted networks.  This is needed if a port is associated with a gateway node that
+    is performing IP routing between subnets.  These should match the format of `allowed_address_pairs`
+    [https://docs.openstack.org/heat/rocky/template_guide/openstack.html#OS::Neutron::Port-prop-allowed_address_pairs here].
+    A simple, permissive configuration for `router_networks` would be: `[ ip_address: "0.0.0.0/0" ]`
 
 `cluster_inventory`: After deployment, an inventory file is generated,
 which can be used in subsequent Ansible-driven configuration.

--- a/files/resources/cluster-group.yaml
+++ b/files/resources/cluster-group.yaml
@@ -42,6 +42,7 @@ parameters:
           - "Cluster::NodeNet"
           - "Cluster::NodeNet1"
           - "Cluster::NodeNet1WithFIP"
+          - "Cluster::NodeNet1WithPreallocatedFIP"
           - "Cluster::NodeNet2"
           - "Cluster::NodeNet3"
   group_idx:
@@ -75,6 +76,11 @@ conditions:
       expression: $.data.cluster_group.containsKey('nodenet_fips')
       data:
         cluster_group: { get_param: [cluster_groups, {get_param: group_idx}] }
+  router_networks_set:
+    yaql:
+      expression: $.data.cluster_group.containsKey('router_networks')
+      data:
+        cluster_group: { get_param: [cluster_groups, {get_param: group_idx}] }
 
 resources:
   port_group:
@@ -93,6 +99,11 @@ resources:
             if:
               - nodenet_fips_set
               - { get_param: [cluster_groups, {get_param: group_idx}, nodenet_fips ] }
+              - []
+          router_networks:
+            if:
+              - router_networks_set
+              - { get_param: [cluster_groups, {get_param: group_idx}, router_networks ] }
               - []
           node_idx: "%index%"
 

--- a/files/resources/nodenet-1.yaml
+++ b/files/resources/nodenet-1.yaml
@@ -16,6 +16,10 @@ parameters:
     type: json
     label: List of UUIDs of prealloacted floating IPs
     default: []
+  router_networks:
+    type: json
+    label: Permit host to route IP traffic from specific networks through this port
+    default: []
 
 conditions:
   security_groups_set:

--- a/files/resources/nodenet-2-w-fip.yaml
+++ b/files/resources/nodenet-2-w-fip.yaml
@@ -16,6 +16,10 @@ parameters:
     type: json
     label: List of UUIDs of prealloacted floating IPs
     default: []
+  router_networks:
+    type: json
+    label: Permit host to route IP traffic from specific networks through this port
+    default: []
 
 conditions:
   security_groups_set:

--- a/files/resources/nodenet-2.yaml
+++ b/files/resources/nodenet-2.yaml
@@ -19,6 +19,10 @@ parameters:
     type: json
     label: List of UUIDs of prealloacted floating IPs
     default: []
+  router_networks:
+    type: json
+    label: Permit host to route IP traffic from specific networks through this port
+    default: []
 
 conditions:
   security_groups_set:

--- a/files/resources/nodenet-3.yaml
+++ b/files/resources/nodenet-3.yaml
@@ -19,6 +19,10 @@ parameters:
     type: json
     label: List of UUIDs of prealloacted floating IPs
     default: []
+  router_networks:
+    type: json
+    label: Permit host to route IP traffic from specific networks through this port
+    default: []
 
 conditions:
   security_groups_set:

--- a/files/resources/nodenet-w-fip.yaml
+++ b/files/resources/nodenet-w-fip.yaml
@@ -1,5 +1,5 @@
 ---
-heat_template_version: pike
+heat_template_version: queens
 
 description: >
   Heat stack template for a stack containing one Neutron port which is on
@@ -15,6 +15,10 @@ parameters:
   cluster_fips:
     type: json
     label: List of UUIDs of prealloacted floating IPs
+    default: []
+  router_networks:
+    type: json
+    label: Permit host to route IP traffic from specific networks through this port
     default: []
 
 conditions:
@@ -34,6 +38,7 @@ resources:
           - security_groups_set
           - { get_param: [ cluster_net, 0, security_groups ] }
           - []
+      allowed_address_pairs: { get_param: router_networks }
       fixed_ips:
         - subnet_id: { get_param: [ cluster_net, 0, subnet ] }
 

--- a/files/resources/nodenet-w-prealloc-fip.yaml
+++ b/files/resources/nodenet-w-prealloc-fip.yaml
@@ -1,5 +1,5 @@
 ---
-heat_template_version: pike
+heat_template_version: queens
 
 description: >
   Heat stack template for a stack containing one Neutron port which is on
@@ -16,6 +16,10 @@ parameters:
   cluster_net:
     type: json
     label: Network names and subnets to which the nodes should be attached
+  router_networks:
+    type: json
+    label: Permit host to route IP traffic from specific networks through this port
+    default: []
 
 conditions:
   security_groups_set:
@@ -34,6 +38,7 @@ resources:
           - security_groups_set
           - { get_param: [ cluster_net, 0, security_groups ] }
           - []
+      allowed_address_pairs: { get_param: router_networks }
       fixed_ips:
         - subnet_id: { get_param: [ cluster_net, 0, subnet ] }
 


### PR DESCRIPTION
Allowed IP addresses permitted to egress the port need to be specified
(or completely relaxed) if the associated host is doing IP routing (eg,
VPN gateways).