### PR TITLE
Add server_networks metadata to the inventory (v19.6.1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
     
 install:
   # Install ansible
-  - pip install ansible
+  - pip install ansible jmespath
 
   # Check ansible version
   - ansible --version

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ The OpenStack APIs should be accessible from the target host.  OpenStack
 Newton or later is required.  Client credentials should have been set
 in the environment, or using the `clouds.yaml` format.
 
-In terms of Python `pip` packages, the requirements are:
+In terms of Python packages, the requirements are:
 - ansible
-- jmespath (required by `json_query` filte)
+- jmespath (required by `json_query` filter)
 
 Role Variables
 --------------

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ The OpenStack APIs should be accessible from the target host.  OpenStack
 Newton or later is required.  Client credentials should have been set
 in the environment, or using the `clouds.yaml` format.
 
+In terms of Python `pip` packages, the requirements are:
+- ansible
+- jmespath (required by `json_query` filte)
+
 Role Variables
 --------------
 

--- a/library/os_server_interface.py
+++ b/library/os_server_interface.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2018 StackHPC Ltd.
+# Apache 2 Licence
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: os_server_interface
+short_description: Create, update and delete server interface.
+author: bharat@stackhpc.com
+version_added: "1.0"
+description:
+    -  Create, update and delete server interface using Openstack Nova API.
+notes:
+    - This module returns C(network_interface) fact, which
+      contains information about server network interfaces.
+requirements:
+    - "python >= 2.6"
+    - "openstacksdk"
+    - "python-novaclient"
+options:
+   cloud:
+     description:
+       - Cloud name inside cloud.yaml file.
+     type: str
+   state:
+     description:
+       - Must be `present`, `query` or `absent`.
+     type: str
+   server_id:
+     description:
+        - Server name or uuid.
+     type: str
+   interfaces:
+     description:
+        - List of network interface names.
+     type: list of str
+extends_documentation_fragment: openstack
+'''
+
+EXAMPLES = '''
+# Attach interfaces to <server_id>:
+- os_container_infra:
+    cloud: mycloud
+    state: present
+    server_id: xxxxx-xxxxx-xxxx-xxxx
+    interfaces:
+    - p3-lln
+    - p3-bdn
+  register: result
+- debug:
+    var: result
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.utils.display import Display
+from novaclient.client import Client
+from novaclient.exceptions import NotFound
+import openstack
+import time
+
+class OpenStackAuthConfig(Exception):
+    pass
+
+class ServerInterface(object):
+    def __init__(self, **kwargs):
+        self.server_id = kwargs['server_id']
+        self.state = kwargs['state']
+    
+        self.connect(**kwargs)
+        self.interfaces = []
+        for interface in kwargs['interfaces']:
+            network = self.cloud.network.find_network(interface)
+            if not network:
+                raise Exception("Unable to find network '%s'" % interface)
+            self.interfaces.append(network)
+
+    def connect(self, **kwargs):
+        if kwargs['auth_type'] == 'password':
+            if kwargs['cloud']:
+                self.cloud = openstack.connect(cloud=kwargs['cloud'])
+            elif kwargs['auth']:
+                self.cloud = openstack.connect(**kwargs['auth'])
+            else:
+                self.cloud = openstack.connect()
+        else:
+            raise OpenStackAuthConfig('Only `password` auth_type is supported.')
+        self.cloud.authorize()
+        self.client = Client('2', session=self.cloud.session)
+
+    def get_server(self):
+        try:
+            server = self.client.servers.find(id=self.server_id)
+        except NotFound:
+            server = self.client.servers.find(name=self.server_id)
+        return server
+
+    def apply(self):
+        changed = False
+        self.server = server = self.get_server()
+        if self.state != 'query':
+            attached_interfaces = server.interface_list()
+            for interface in self.interfaces:
+                interface_exists = False
+                for attached_interface in attached_interfaces:
+                    if interface.id == attached_interface.net_id:
+                        if self.state == 'absent':
+                            server.interface_detach(port_id=attached_interface.port_id)
+                            changed = True
+                        elif self.state == 'present':
+                            interface_exists = True
+                if interface_exists == False and self.state == 'present':
+                    server.interface_attach(port_id=None, net_id=interface.id, fixed_ip=None)
+                    changed = True
+            if changed:
+                self.server = self.get_server()
+        return changed
+
+if __name__ == '__main__':
+    module = AnsibleModule(
+        argument_spec = dict(
+            cloud=dict(required=False, type='str'),
+            auth=dict(required=False, type='dict'),
+            auth_type=dict(default='password', required=False, type='str'),
+            state=dict(default='present', choices=['present','absent', 'query']),
+            server_id=dict(required=True, type='str'),
+            interfaces=dict(default=[], type='list'),
+        ),
+        supports_check_mode=False
+    )
+
+    display = Display()
+
+    try:
+        server_interface = ServerInterface(**module.params)
+        changed = server_interface.apply()
+    except Exception as e:
+        module.fail_json(msg=repr(e))
+
+    server = server_interface.server
+
+    module.exit_json(
+        changed=changed,
+        server_name=server.name,
+        server_networks=server.networks,
+    )

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,11 +34,31 @@
     - name: Gather OpenStack infrastructure information
       command: openstack stack output show {{ cluster_name }} cluster_group -f json
       register: stack_output
+      changed_when: false
 
     - name: Extract node groups
       set_fact:
         cluster_group: "{{ stack_output.stdout | from_json }}"
   when: cluster_state == 'query'
+
+- name: Extract server ids from cluster group output
+  set_fact:
+    cluster_servers: "{{ cluster_group.output_value | json_query('[*].nodes[*].id') | flatten }}"
+    cluster_interfaces: "{{ cluster_net | map(attribute='net') | list }}"
+
+- name: Attach interfaces to servers
+  os_server_interface:
+    auth_type: "{{ cluster_auth_type or omit }}"
+    auth: "{{ cluster_auth or omit }}"
+    cloud: "{{ cluster_cloud or omit }}"
+    state: "{{ cluster_state }}"
+    server_id: "{{ item }}"
+    interfaces: "{{ cluster_interfaces }}"
+  with_items: "{{ cluster_servers }}"
+  register: openstack_server_interfaces
+
+- set_fact:
+    cluster_server_interfaces: "{{ dict(cluster_servers | zip(openstack_server_interfaces.results)) }}"
 
 - name: Reset the python interpreter
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,11 +41,6 @@
         cluster_group: "{{ stack_output.stdout | from_json }}"
   when: cluster_state == 'query'
 
-- name: Reset the python interpreter
-  set_fact:
-    ansible_python_interpreter: "{{ old_python_interpreter }}"
-  when: cluster_venv != None
-
 - block:
     - name: Extract server ids from cluster group output
       set_fact:
@@ -130,3 +125,9 @@
       delegate_to: "{{ cluster_gw_ip | default('localhost') }}"
 
   when: cluster_state in ['present', 'query']
+
+- name: Reset the python interpreter
+  set_fact:
+    ansible_python_interpreter: "{{ old_python_interpreter }}"
+  when: cluster_venv != None
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,31 +41,32 @@
         cluster_group: "{{ stack_output.stdout | from_json }}"
   when: cluster_state == 'query'
 
-- name: Extract server ids from cluster group output
-  set_fact:
-    cluster_servers: "{{ cluster_group.output_value | json_query('[*].nodes[*].id') | flatten }}"
-    cluster_interfaces: "{{ cluster_net | map(attribute='net') | list }}"
-
-- name: Attach interfaces to servers
-  os_server_interface:
-    auth_type: "{{ cluster_auth_type or omit }}"
-    auth: "{{ cluster_auth or omit }}"
-    cloud: "{{ cluster_cloud or omit }}"
-    state: "{{ cluster_state }}"
-    server_id: "{{ item }}"
-    interfaces: "{{ cluster_interfaces }}"
-  with_items: "{{ cluster_servers }}"
-  register: openstack_server_interfaces
-
-- set_fact:
-    cluster_server_interfaces: "{{ dict(cluster_servers | zip(openstack_server_interfaces.results)) }}"
-
 - name: Reset the python interpreter
   set_fact:
     ansible_python_interpreter: "{{ old_python_interpreter }}"
   when: cluster_venv != None
 
 - block:
+    - name: Extract server ids from cluster group output
+      set_fact:
+        cluster_servers: "{{ cluster_group.output_value | json_query('[*].nodes[*].id') | flatten }}"
+        cluster_interfaces: "{{ cluster_net | map(attribute='net') | list }}"
+
+    - name: Attach interfaces to servers
+      os_server_interface:
+        auth_type: "{{ cluster_auth_type or omit }}"
+        auth: "{{ cluster_auth or omit }}"
+        cloud: "{{ cluster_cloud or omit }}"
+        state: "{{ cluster_state }}"
+        server_id: "{{ item }}"
+        interfaces: "{{ cluster_interfaces }}"
+      with_items: "{{ cluster_servers }}"
+      register: openstack_server_interfaces
+
+    - name: Convert list of interfaces to a dictionary for easy lookup in inventory templating step
+      set_fact:
+        cluster_server_interfaces: "{{ dict(cluster_servers | zip(openstack_server_interfaces.results)) }}"
+
     - name: Extract node objects
       set_fact:
         cluster_nodes: "{{ cluster_group.output_value | sum(attribute='nodes', start=[]) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
     - name: Extract node groups
       set_fact:
         cluster_group: "{{ cluster_stack.stack.outputs | selectattr('output_key', 'equalto', 'cluster_group') | first }}"
-  when: cluster_state != 'query'
+  when: cluster_state in ['present', 'absent']
 
 # Case 2: we are performing a read-only query of the cluster configuration.
 # Read the stack's outputs via the API.
@@ -129,4 +129,4 @@
         - "{{ cluster_nodes }}"
       delegate_to: "{{ cluster_gw_ip | default('localhost') }}"
 
-  when: cluster_state != 'absent'
+  when: cluster_state in ['present', 'query']

--- a/templates/cluster_inventory.j2
+++ b/templates/cluster_inventory.j2
@@ -16,7 +16,7 @@ cluster
 {% for group_data in cluster_group.output_value %}
 [{{ cluster_name }}_{{ group_data.group }}]
 {% for node_data in group_data.nodes %}
-{{ node_data.name }} ansible_host={{ node_data.ip }}
+{{ node_data.name }} ansible_host={{ node_data.ip }} server_networks='{{ cluster_server_interfaces[node_data.id].server_networks | to_json }}'
 {% endfor %}
 
 [{{ cluster_name }}_{{ group_data.group }}:vars]


### PR DESCRIPTION
This brings the role on par with os-container-infra.

Use case: when the network is not sometimes correctly configured when the instance boots up, having the network IP metadata in the inventory allows us to  configure, e.g. Infiniband interface.